### PR TITLE
Implements proper SIGINT handling and fixes silent failure in inotify_add_watch.

### DIFF
--- a/src/core/watcher.cpp
+++ b/src/core/watcher.cpp
@@ -3,11 +3,12 @@
 #include <unistd.h>
 #include <sys/inotify.h>
 #include <cstring>
+#include <csignal>
 
 Watcher::Watcher(std::string path_to_watch) : watch_path(std::move(path_to_watch)) {}
 //Watcher::~Watcher() { stop(); }
 void Watcher::setCallback(EventCallback cb) { callback = std::move(cb); }
-
+void Watcher::stop() { running = false; }
 void Watcher::start() {
     std::cout << "Watcher starting for path: " << watch_path << '\n';
     inotify_id = inotify_init();
@@ -16,11 +17,17 @@ void Watcher::start() {
         return;
     }
     int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
+    if (wd <= 0) {
+        perror("inotify_add_watch");
+        return;
+    }
+    std::cout << "Watching " << watch_path << " (wd:" << wd << ")\n";
     char buf[4096];
     running = true;
     while (running) {
         ssize_t len = read(inotify_id, buf, sizeof(buf));
-        if (len <= 0) {
+        if (len < 0) {
+            if (errno == EINTR) break;
             perror("read");
             continue;
         }
@@ -47,8 +54,20 @@ void Watcher::start() {
     close(inotify_id);
 }
 
+Watcher* cwatcher = nullptr;
+
+void handler(int) {
+    if (cwatcher) cwatcher->stop();
+}
+
 int main() {
     Watcher watchr("./");
+    cwatcher = &watchr;
+    struct sigaction sa{};
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, nullptr);
     watchr.setCallback([](const std::string& path, const std::string& type) { std::cout << "|Callback| " << type << " -> " << path << '\n'; });
     watchr.start();
     return 0;

--- a/src/core/watcher.cpp
+++ b/src/core/watcher.cpp
@@ -1,0 +1,55 @@
+#include "watcher.hpp"
+#include <iostream>
+#include <unistd.h>
+#include <sys/inotify.h>
+#include <cstring>
+
+Watcher::Watcher(std::string path_to_watch) : watch_path(std::move(path_to_watch)) {}
+//Watcher::~Watcher() { stop(); }
+void Watcher::setCallback(EventCallback cb) { callback = std::move(cb); }
+
+void Watcher::start() {
+    std::cout << "Watcher starting for path: " << watch_path << '\n';
+    inotify_id = inotify_init();
+    if (inotify_id == -1) {
+        std::cerr << "Failed to initialize inotify: " << strerror(errno) << '\n';
+        return;
+    }
+    int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
+    char buf[4096];
+    running = true;
+    while (running) {
+        ssize_t len = read(inotify_id, buf, sizeof(buf));
+        if (len <= 0) {
+            perror("read");
+            continue;
+        }
+        ssize_t i = 0;
+        while (i < len) {
+            auto* event = reinterpret_cast<inotify_event*>(&buf[i]);
+            if (event->len > 0) {
+                std::string file = event->name;
+                std::string type;
+                if (event->mask & IN_CLOSE_WRITE) type = "WRITE";
+                else if (event->mask & IN_MODIFY) type = "MODIFY";
+                else if (event->mask & IN_CREATE) type = "CREATE";
+                else if (event->mask & IN_DELETE) type = "DELETE";
+                else if (event->mask & IN_MOVED_TO) type = "MOVE";
+                if (!type.empty()) {
+                    std::cout << "|Watcher| " << type << ": " << file << '\n';
+                    if (callback) callback(file, type);
+                }
+            }
+            i += sizeof(inotify_event) + event->len;
+        }
+    }
+    inotify_rm_watch(inotify_id, wd);
+    close(inotify_id);
+}
+
+int main() {
+    Watcher watchr("./");
+    watchr.setCallback([](const std::string& path, const std::string& type) { std::cout << "|Callback| " << type << " -> " << path << '\n'; });
+    watchr.start();
+    return 0;
+}

--- a/src/core/watcher.hpp
+++ b/src/core/watcher.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <string>
+#include <functional>
+
+class Watcher {
+    public:
+        explicit Watcher(std::string path_to_watch);
+        //~Watcher();
+        void start();
+        void stop();
+        using EventCallback = std::function<void(const std::string& file_path, const std::string& event_type)>;
+        void setCallback(EventCallback cb);
+    private:
+        std::string watch_path;
+        int inotify_id = -1;
+        bool running = false;
+        EventCallback callback;
+};


### PR DESCRIPTION
Adds a signal handler to intercept Ctrl+C and trigger a clean shutdown via stop(), allowing the watcher loop to exit and resources (inotify_rm_watch, close) to be released correctly.

Also adds error checking for inotify_add_watch to prevent silent failures when the watch descriptor is not created. On failure, an error is reported instead of continuing in an invalid state.
Closes #3, #7 