### PR TITLE
Run watcher loop in separate thread and implement graceful shutdown

### DIFF
--- a/src/core/watcher.cpp
+++ b/src/core/watcher.cpp
@@ -3,11 +3,12 @@
 #include <unistd.h>
 #include <sys/inotify.h>
 #include <cstring>
+#include <csignal>
 
 Watcher::Watcher(std::string path_to_watch) : watch_path(std::move(path_to_watch)) {}
 //Watcher::~Watcher() { stop(); }
 void Watcher::setCallback(EventCallback cb) { callback = std::move(cb); }
-
+void Watcher::stop() { running = false; }
 void Watcher::start() {
     std::cout << "Watcher starting for path: " << watch_path << '\n';
     inotify_id = inotify_init();
@@ -16,11 +17,17 @@ void Watcher::start() {
         return;
     }
     int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
+    if (wd <= 0) {
+        perror("inotify_add_watch");
+        return;
+    }
+    std::cout << "Watching " << watch_path << " (wd:" << wd << ")\n";
     char buf[4096];
     running = true;
     while (running) {
         ssize_t len = read(inotify_id, buf, sizeof(buf));
-        if (len <= 0) {
+        if (len < 0) {
+            if (errno == EINTR) break;
             perror("read");
             continue;
         }
@@ -47,8 +54,20 @@ void Watcher::start() {
     close(inotify_id);
 }
 
+Watcher* cwatcher = nullptr;
+
+void handler(int) {
+    if (cwatcher) cwatcher->stop();
+}
+
 int main() {
     Watcher watchr("./");
+    cwatcher = &watchr;
+    struct sigaction sa{};
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, nullptr);
     watchr.setCallback([](const std::string& path, const std::string& type) { std::cout << "|Callback| " << type << " -> " << path << '\n'; });
     watchr.start();
     return 0;

--- a/src/core/watcher.cpp
+++ b/src/core/watcher.cpp
@@ -1,0 +1,55 @@
+#include "watcher.hpp"
+#include <iostream>
+#include <unistd.h>
+#include <sys/inotify.h>
+#include <cstring>
+
+Watcher::Watcher(std::string path_to_watch) : watch_path(std::move(path_to_watch)) {}
+//Watcher::~Watcher() { stop(); }
+void Watcher::setCallback(EventCallback cb) { callback = std::move(cb); }
+
+void Watcher::start() {
+    std::cout << "Watcher starting for path: " << watch_path << '\n';
+    inotify_id = inotify_init();
+    if (inotify_id == -1) {
+        std::cerr << "Failed to initialize inotify: " << strerror(errno) << '\n';
+        return;
+    }
+    int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
+    char buf[4096];
+    running = true;
+    while (running) {
+        ssize_t len = read(inotify_id, buf, sizeof(buf));
+        if (len <= 0) {
+            perror("read");
+            continue;
+        }
+        ssize_t i = 0;
+        while (i < len) {
+            auto* event = reinterpret_cast<inotify_event*>(&buf[i]);
+            if (event->len > 0) {
+                std::string file = event->name;
+                std::string type;
+                if (event->mask & IN_CLOSE_WRITE) type = "WRITE";
+                else if (event->mask & IN_MODIFY) type = "MODIFY";
+                else if (event->mask & IN_CREATE) type = "CREATE";
+                else if (event->mask & IN_DELETE) type = "DELETE";
+                else if (event->mask & IN_MOVED_TO) type = "MOVE";
+                if (!type.empty()) {
+                    std::cout << "|Watcher| " << type << ": " << file << '\n';
+                    if (callback) callback(file, type);
+                }
+            }
+            i += sizeof(inotify_event) + event->len;
+        }
+    }
+    inotify_rm_watch(inotify_id, wd);
+    close(inotify_id);
+}
+
+int main() {
+    Watcher watchr("./");
+    watchr.setCallback([](const std::string& path, const std::string& type) { std::cout << "|Callback| " << type << " -> " << path << '\n'; });
+    watchr.start();
+    return 0;
+}

--- a/src/core/watcher.cpp
+++ b/src/core/watcher.cpp
@@ -3,78 +3,97 @@
 #include <unistd.h>
 #include <sys/inotify.h>
 #include <cstring>
+#include <cerrno>
+#include <chrono>
 #include <csignal>
 
 Watcher::Watcher(std::string path_to_watch) : watch_path(std::move(path_to_watch)) {}
-//Watcher::~Watcher() { stop(); }
-void Watcher::setCallback(EventCallback cb) { callback = std::move(cb); }
+void Watcher::setCallback(EventCallback cb) {
+    std::lock_guard<std::mutex> lock(callback_mutex);
+    callback = std::move(cb);
+}
+Watcher::~Watcher() { stop(); }
 void Watcher::stop() { 
-    running = false; 
-    if (inotify_id != -1) close(inotify_id);
+    if (!running.exchange(false)) return;
     if (worker.joinable()) worker.join();
 }
 
 void Watcher::start() {
-    running = true;
+    if (running.exchange(true)) return;
     worker = std::thread([this]() {
-        char buf[4096];
-        inotify_id = inotify_init();
-        if (inotify_id == -1) {
+        int fd = inotify_init1(IN_NONBLOCK);
+        if (fd == -1) {
             std::cerr << "Failed to initialize inotify: " << strerror(errno) << '\n';
+            running = false;
             return;
         }
-        int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
-        if (wd <= 0) {
-            perror("inotify_add_watch");
+        int wd = inotify_add_watch(fd, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MOVED_TO | IN_MOVED_FROM);
+        if (wd == -1) {
+            std::cerr << "Failed to add watch: " << strerror(errno) << '\n';
+            close(fd);
+            running = false;
             return;
         }
+        alignas(inotify_event) char buf[4096];
         while (running) {
-            ssize_t len = read(inotify_id, buf, sizeof(buf));
+            ssize_t len = read(fd, buf, sizeof(buf));
             if (len < 0) {
-                if (errno == EINTR) break;
-                perror("read");
-                continue;
+                if (errno == EAGAIN) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                    continue;
+                }
+                if (errno == EINTR) continue;
+                std::cerr << "read error: " << strerror(errno) << '\n';
+                break;
             }
             ssize_t i = 0;
             while (i < len) {
-                auto* event = reinterpret_cast<inotify_event*>(&buf[i]);
+                auto* event = reinterpret_cast<inotify_event*>(buf + i);
                 if (event->len > 0) {
-                    std::string file = event->name;
-                    std::string type;
-                    if (event->mask & IN_CLOSE_WRITE) type = "WRITE";
-                    else if (event->mask & IN_MODIFY) type = "MODIFY";
-                    else if (event->mask & IN_CREATE) type = "CREATE";
-                    else if (event->mask & IN_DELETE) type = "DELETE";
-                    else if (event->mask & IN_MOVED_TO) type = "MOVE";
-                    if (!type.empty()) {
-                        std::cout << "|Watcher| " << type << ": " << file << '\n';
-                        if (callback) callback(file, type);
+                    std::string filename = event->name;
+                    EventCallback cb_copy;
+                    {
+                        std::lock_guard<std::mutex> lock(callback_mutex);
+                        cb_copy = callback;
+                    }
+                    if (cb_copy) {
+                        if (event->mask & IN_CREATE) cb_copy(name, "CREATE");
+                        if (event->mask & IN_DELETE) cb_copy(name, "DELETE");
+                        if (event->mask & IN_CLOSE_WRITE) cb_copy(name, "MODIFY");
+                        if (event->mask & IN_MOVED_TO) cb_copy(name, "MOVED_TO");
+                        if (event->mask & IN_MOVED_FROM) cb_copy(name, "MOVED_FROM");
                     }
                 }
                 i += sizeof(inotify_event) + event->len;
             }
         }
-        inotify_rm_watch(inotify_id, wd);
-        close(inotify_id);
+        inotify_rm_watch(fd, wd);
+        close(fd);
     });
 }
 
-Watcher* cwatcher = nullptr;
+std::atomic<bool> shutdown_requested{false};
 
 void handler(int) {
-    if (cwatcher) cwatcher->stop();
+    shutdown_requested = true;
 }
 
 int main() {
     Watcher watchr("./");
-    cwatcher = &watchr;
     struct sigaction sa{};
     sa.sa_handler = handler;
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
     sigaction(SIGINT, &sa, nullptr);
-    watchr.setCallback([](const std::string& path, const std::string& type) { std::cout << "|Callback| " << type << " -> " << path << '\n'; });
+    watchr.setCallback([](const std::string& path, const std::string& type) { 
+            std::cout << type << " -> " << path << '\n';
+    });
     watchr.start();
-    pause();
+    std::cout << "[Main] Watcher is running. Press Ctrl+C to stop.\n";
+    while (!shutdown_requested) {
+        std::this_thread::sleep_for(std::chrono::seconds(100));
+    }
+    std::cout << "\n[Main] Shutting down...\n";
+    watchr.stop();
     return 0;
 }

--- a/src/core/watcher.cpp
+++ b/src/core/watcher.cpp
@@ -8,50 +8,55 @@
 Watcher::Watcher(std::string path_to_watch) : watch_path(std::move(path_to_watch)) {}
 //Watcher::~Watcher() { stop(); }
 void Watcher::setCallback(EventCallback cb) { callback = std::move(cb); }
-void Watcher::stop() { running = false; }
+void Watcher::stop() { 
+    running = false; 
+    if (inotify_id != -1) close(inotify_id);
+    if (worker.joinable()) worker.join();
+}
+
 void Watcher::start() {
-    std::cout << "Watcher starting for path: " << watch_path << '\n';
-    inotify_id = inotify_init();
-    if (inotify_id == -1) {
-        std::cerr << "Failed to initialize inotify: " << strerror(errno) << '\n';
-        return;
-    }
-    int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
-    if (wd <= 0) {
-        perror("inotify_add_watch");
-        return;
-    }
-    std::cout << "Watching " << watch_path << " (wd:" << wd << ")\n";
-    char buf[4096];
     running = true;
-    while (running) {
-        ssize_t len = read(inotify_id, buf, sizeof(buf));
-        if (len < 0) {
-            if (errno == EINTR) break;
-            perror("read");
-            continue;
+    worker = std::thread([this]() {
+        char buf[4096];
+        inotify_id = inotify_init();
+        if (inotify_id == -1) {
+            std::cerr << "Failed to initialize inotify: " << strerror(errno) << '\n';
+            return;
         }
-        ssize_t i = 0;
-        while (i < len) {
-            auto* event = reinterpret_cast<inotify_event*>(&buf[i]);
-            if (event->len > 0) {
-                std::string file = event->name;
-                std::string type;
-                if (event->mask & IN_CLOSE_WRITE) type = "WRITE";
-                else if (event->mask & IN_MODIFY) type = "MODIFY";
-                else if (event->mask & IN_CREATE) type = "CREATE";
-                else if (event->mask & IN_DELETE) type = "DELETE";
-                else if (event->mask & IN_MOVED_TO) type = "MOVE";
-                if (!type.empty()) {
-                    std::cout << "|Watcher| " << type << ": " << file << '\n';
-                    if (callback) callback(file, type);
-                }
+        int wd = inotify_add_watch(inotify_id, watch_path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE);
+        if (wd <= 0) {
+            perror("inotify_add_watch");
+            return;
+        }
+        while (running) {
+            ssize_t len = read(inotify_id, buf, sizeof(buf));
+            if (len < 0) {
+                if (errno == EINTR) break;
+                perror("read");
+                continue;
             }
-            i += sizeof(inotify_event) + event->len;
+            ssize_t i = 0;
+            while (i < len) {
+                auto* event = reinterpret_cast<inotify_event*>(&buf[i]);
+                if (event->len > 0) {
+                    std::string file = event->name;
+                    std::string type;
+                    if (event->mask & IN_CLOSE_WRITE) type = "WRITE";
+                    else if (event->mask & IN_MODIFY) type = "MODIFY";
+                    else if (event->mask & IN_CREATE) type = "CREATE";
+                    else if (event->mask & IN_DELETE) type = "DELETE";
+                    else if (event->mask & IN_MOVED_TO) type = "MOVE";
+                    if (!type.empty()) {
+                        std::cout << "|Watcher| " << type << ": " << file << '\n';
+                        if (callback) callback(file, type);
+                    }
+                }
+                i += sizeof(inotify_event) + event->len;
+            }
         }
-    }
-    inotify_rm_watch(inotify_id, wd);
-    close(inotify_id);
+        inotify_rm_watch(inotify_id, wd);
+        close(inotify_id);
+    });
 }
 
 Watcher* cwatcher = nullptr;
@@ -70,5 +75,6 @@ int main() {
     sigaction(SIGINT, &sa, nullptr);
     watchr.setCallback([](const std::string& path, const std::string& type) { std::cout << "|Callback| " << type << " -> " << path << '\n'; });
     watchr.start();
+    pause();
     return 0;
 }

--- a/src/core/watcher.hpp
+++ b/src/core/watcher.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <string>
+#include <functional>
+
+class Watcher {
+    public:
+        explicit Watcher(std::string path_to_watch);
+        //~Watcher();
+        void start();
+        void stop();
+        using EventCallback = std::function<void(const std::string& file_path, const std::string& event_type)>;
+        void setCallback(EventCallback cb);
+    private:
+        std::string watch_path;
+        int inotify_id = -1;
+        bool running = false;
+        EventCallback callback;
+};

--- a/src/core/watcher.hpp
+++ b/src/core/watcher.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <thread>
 #include <functional>
 
 class Watcher {
@@ -15,4 +16,5 @@ class Watcher {
         int inotify_id = -1;
         bool running = false;
         EventCallback callback;
+        std::thread worker;
 };

--- a/src/core/watcher.hpp
+++ b/src/core/watcher.hpp
@@ -1,12 +1,13 @@
 #pragma once
 #include <string>
 #include <thread>
+#include <atomic>
 #include <functional>
 
 class Watcher {
     public:
         explicit Watcher(std::string path_to_watch);
-        //~Watcher();
+        ~Watcher();
         void start();
         void stop();
         using EventCallback = std::function<void(const std::string& file_path, const std::string& event_type)>;
@@ -14,7 +15,8 @@ class Watcher {
     private:
         std::string watch_path;
         int inotify_id = -1;
-        bool running = false;
+        std::atomic<bool> running{false};
         EventCallback callback;
+        std::mutex callback_mutex;
         std::thread worker;
 };


### PR DESCRIPTION
This PR refactors the Watcher implementation to run the inotify loop in a dedicated std::thread instead of blocking the main thread.

Changes:
- Moved blocking loop from start() into a worker thread
- Introduced std::atomic<bool> running flag for lifecycle control
- Implemented safe shutdown via stop() with proper thread join
- Replaced unsafe signal handling with atomic shutdown flag
- Improved callback handling to avoid deadlocks (copy before execution)
- Added support for additional inotify events (IN_MOVED_FROM)

As a result, start() no longer blocks the caller, and the watcher operates asynchronously as intended.